### PR TITLE
fix: cannot click on CTA buttons if the input value is empty

### DIFF
--- a/src/components/UI/molecules/reporting/CastYourVote.jsx
+++ b/src/components/UI/molecules/reporting/CastYourVote.jsx
@@ -78,7 +78,7 @@ export const CastYourVote = () => {
               "flex-auto px-8 py-6 text-h5 font-bold whitespace-nowrap"
             }
             onClick={handleApproveClick}
-            disabled={!stakedAmount && true}
+            disabled={!stakedAmount}
           >
             APPROVE NPM
           </RegularButton>
@@ -90,7 +90,7 @@ export const CastYourVote = () => {
               "flex-auto px-8 py-6 text-h5 font-bold whitespace-nowrap"
             }
             onClick={handleReportClick}
-            disabled={!stakedAmount && true}
+            disabled={!stakedAmount}
           >
             REPORT
           </RegularButton>

--- a/src/components/UI/molecules/reporting/CastYourVote.jsx
+++ b/src/components/UI/molecules/reporting/CastYourVote.jsx
@@ -78,6 +78,7 @@ export const CastYourVote = () => {
               "flex-auto px-8 py-6 text-h5 font-bold whitespace-nowrap"
             }
             onClick={handleApproveClick}
+            disabled={!stakedAmount && true}
           >
             APPROVE NPM
           </RegularButton>
@@ -89,6 +90,7 @@ export const CastYourVote = () => {
               "flex-auto px-8 py-6 text-h5 font-bold whitespace-nowrap"
             }
             onClick={handleReportClick}
+            disabled={!stakedAmount && true}
           >
             REPORT
           </RegularButton>

--- a/src/components/UI/molecules/reporting/UnstakeYourAmount.jsx
+++ b/src/components/UI/molecules/reporting/UnstakeYourAmount.jsx
@@ -42,7 +42,7 @@ const UnstakeYourAmount = () => {
         <RegularButton
           className={"flex-auto px-8 py-6 text-h5 font-bold whitespace-nowrap"}
           onClick={handleUnstakeClick}
-          disabled={!unstakedAmount && true}
+          disabled={!unstakedAmount}
         >
           UNSTAKE NPM
         </RegularButton>

--- a/src/components/UI/molecules/reporting/UnstakeYourAmount.jsx
+++ b/src/components/UI/molecules/reporting/UnstakeYourAmount.jsx
@@ -42,6 +42,7 @@ const UnstakeYourAmount = () => {
         <RegularButton
           className={"flex-auto px-8 py-6 text-h5 font-bold whitespace-nowrap"}
           onClick={handleUnstakeClick}
+          disabled={!unstakedAmount && true}
         >
           UNSTAKE NPM
         </RegularButton>

--- a/src/components/UI/organisms/cover-form/add-liquidity.jsx
+++ b/src/components/UI/organisms/cover-form/add-liquidity.jsx
@@ -56,7 +56,7 @@ export const CoverFormAddLiquidity = () => {
       </div>
 
       <RegularButton
-        disabled={!value && true}
+        disabled={!value}
         className="w-full mt-8 p-6 text-h6 uppercase font-semibold"
       >
         Provide Liquidity

--- a/src/components/UI/organisms/cover-form/add-liquidity.jsx
+++ b/src/components/UI/organisms/cover-form/add-liquidity.jsx
@@ -19,7 +19,7 @@ export const CoverFormAddLiquidity = () => {
     setReceiveAmount(parseFloat(0.99 * maxValue).toFixed(2));
   };
 
-   const handleChange = (e) => {
+  const handleChange = (e) => {
     const willRecieve = parseFloat(0.99 * e.target.value).toFixed(2);
     setValue(e.target.value);
     setReceiveAmount(willRecieve);
@@ -55,7 +55,10 @@ export const CoverFormAddLiquidity = () => {
         <UnlockDate dateValue="September 22, 2021 12:34:00 PM UTC" />
       </div>
 
-      <RegularButton className="w-full mt-8 p-6 text-h6 uppercase font-semibold">
+      <RegularButton
+        disabled={!value && true}
+        className="w-full mt-8 p-6 text-h6 uppercase font-semibold"
+      >
         Provide Liquidity
       </RegularButton>
 

--- a/src/components/UI/organisms/cover-form/my-liquidity/index.jsx
+++ b/src/components/UI/organisms/cover-form/my-liquidity/index.jsx
@@ -58,6 +58,7 @@ export const CoverFormMyLiquidity = () => {
       <RegularButton
         className="w-full mt-8 p-6 text-h6 uppercase font-semibold"
         onClick={() => null}
+        disabled={!value && true}
       >
         Add Liquidity
       </RegularButton>

--- a/src/components/UI/organisms/cover-form/my-liquidity/index.jsx
+++ b/src/components/UI/organisms/cover-form/my-liquidity/index.jsx
@@ -58,7 +58,7 @@ export const CoverFormMyLiquidity = () => {
       <RegularButton
         className="w-full mt-8 p-6 text-h6 uppercase font-semibold"
         onClick={() => null}
-        disabled={!value && true}
+        disabled={!value}
       >
         Add Liquidity
       </RegularButton>

--- a/src/components/UI/organisms/cover-form/my-liquidity/modal-form.jsx
+++ b/src/components/UI/organisms/cover-form/my-liquidity/modal-form.jsx
@@ -63,7 +63,7 @@ export const WithdrawLiquidityModal = ({
         <RegularButton
           onClick={() => handleWithdraw(id)}
           className="w-full mt-8 p-6 text-h6 uppercase font-semibold"
-          disabled={!value && true}
+          disabled={!value}
         >
           Withdraw
         </RegularButton>

--- a/src/components/UI/organisms/cover-form/my-liquidity/modal-form.jsx
+++ b/src/components/UI/organisms/cover-form/my-liquidity/modal-form.jsx
@@ -14,7 +14,6 @@ export const WithdrawLiquidityModal = ({
   onClose,
   unitName,
 }) => {
-
   const [value, setValue] = useState();
   const [receiveAmount, setReceiveAmount] = useState();
   const { maxValue } = useConstants();
@@ -24,7 +23,7 @@ export const WithdrawLiquidityModal = ({
     setReceiveAmount(parseFloat(0.99 * maxValue).toFixed(2));
   };
 
-   const handleChange = (e) => {
+  const handleChange = (e) => {
     const willRecieve = parseFloat(0.99 * e.target.value).toFixed(2);
     setValue(e.target.value);
     setReceiveAmount(willRecieve);
@@ -64,6 +63,7 @@ export const WithdrawLiquidityModal = ({
         <RegularButton
           onClick={() => handleWithdraw(id)}
           className="w-full mt-8 p-6 text-h6 uppercase font-semibold"
+          disabled={!value && true}
         >
           Withdraw
         </RegularButton>

--- a/src/components/UI/organisms/my-policies/ClaimCoverModal.jsx
+++ b/src/components/UI/organisms/my-policies/ClaimCoverModal.jsx
@@ -53,7 +53,7 @@ export const ClaimCoverModal = ({ modalTitle, isOpen, onClose }) => {
           <p className="text-9B9B9B pt-2 px-3">Fee: 6.50%</p>
         </div>
         <RegularButton
-          disabled={!value && true}
+          disabled={!value}
           className="w-full mt-8 p-6 text-h6 uppercase font-semibold"
         >
           Claim

--- a/src/components/UI/organisms/my-policies/ClaimCoverModal.jsx
+++ b/src/components/UI/organisms/my-policies/ClaimCoverModal.jsx
@@ -52,7 +52,10 @@ export const ClaimCoverModal = ({ modalTitle, isOpen, onClose }) => {
           <DisabledInput value={receiveAmount} unit="DAI" />
           <p className="text-9B9B9B pt-2 px-3">Fee: 6.50%</p>
         </div>
-        <RegularButton className="w-full mt-8 p-6 text-h6 uppercase font-semibold">
+        <RegularButton
+          disabled={!value && true}
+          className="w-full mt-8 p-6 text-h6 uppercase font-semibold"
+        >
           Claim
         </RegularButton>
       </div>

--- a/src/components/UI/organisms/pools/staking/amount-to-stake-modal.jsx
+++ b/src/components/UI/organisms/pools/staking/amount-to-stake-modal.jsx
@@ -61,7 +61,7 @@ export const AmountToStakeModal = ({
         <RegularButton
           onClick={() => handleStake(id)}
           className="w-full mt-8 p-6 text-h6 uppercase font-semibold"
-          disabled={!inputValue && true}
+          disabled={!inputValue}
         >
           Stake
         </RegularButton>

--- a/src/components/UI/organisms/pools/staking/amount-to-stake-modal.jsx
+++ b/src/components/UI/organisms/pools/staking/amount-to-stake-modal.jsx
@@ -61,6 +61,7 @@ export const AmountToStakeModal = ({
         <RegularButton
           onClick={() => handleStake(id)}
           className="w-full mt-8 p-6 text-h6 uppercase font-semibold"
+          disabled={!inputValue && true}
         >
           Stake
         </RegularButton>

--- a/src/components/UI/organisms/pools/staking/withdraw-form.jsx
+++ b/src/components/UI/organisms/pools/staking/withdraw-form.jsx
@@ -28,7 +28,7 @@ export const WithdrawForm = ({ onWithdraw, unitName }) => {
       <RegularButton
         onClick={onWithdraw}
         className={"w-full mt-8 p-6 text-h6 uppercase font-semibold"}
-        disabled={!amtToWithdraw && true}
+        disabled={!amtToWithdraw}
       >
         Collect
       </RegularButton>

--- a/src/components/UI/organisms/pools/staking/withdraw-form.jsx
+++ b/src/components/UI/organisms/pools/staking/withdraw-form.jsx
@@ -28,6 +28,7 @@ export const WithdrawForm = ({ onWithdraw, unitName }) => {
       <RegularButton
         onClick={onWithdraw}
         className={"w-full mt-8 p-6 text-h6 uppercase font-semibold"}
+        disabled={!amtToWithdraw && true}
       >
         Collect
       </RegularButton>

--- a/src/components/pages/pools/bond/index.jsx
+++ b/src/components/pages/pools/bond/index.jsx
@@ -121,6 +121,7 @@ const BondPage = () => {
         <RegularButton
           className={"w-full mt-8 p-6 text-h6 uppercase font-semibold"}
           onClick={handleApprove}
+          disabled={!value && true}
         >
           Approve NPM-USDC LP
         </RegularButton>

--- a/src/components/pages/pools/bond/index.jsx
+++ b/src/components/pages/pools/bond/index.jsx
@@ -121,7 +121,7 @@ const BondPage = () => {
         <RegularButton
           className={"w-full mt-8 p-6 text-h6 uppercase font-semibold"}
           onClick={handleApprove}
-          disabled={!value && true}
+          disabled={!value}
         >
           Approve NPM-USDC LP
         </RegularButton>

--- a/src/components/pages/reporting/new/NewIncidentReportForm.jsx
+++ b/src/components/pages/reporting/new/NewIncidentReportForm.jsx
@@ -163,6 +163,7 @@ export const NewIncidentReportForm = () => {
             <RegularButton
               className="text-h6 font-bold py-6 px-24 mt-16"
               onClick={handleReportClick}
+              disabled={!staked && true}
             >
               REPORT
             </RegularButton>

--- a/src/components/pages/reporting/new/NewIncidentReportForm.jsx
+++ b/src/components/pages/reporting/new/NewIncidentReportForm.jsx
@@ -163,7 +163,7 @@ export const NewIncidentReportForm = () => {
             <RegularButton
               className="text-h6 font-bold py-6 px-24 mt-16"
               onClick={handleReportClick}
-              disabled={!staked && true}
+              disabled={!staked}
             >
               REPORT
             </RegularButton>


### PR DESCRIPTION
added disabled option to buttons on requesting claim, approve, stake, like operations