### PR TITLE
refactored resolution sources to have corresponding links

### DIFF
--- a/src/_mocks/cover/available.js
+++ b/src/_mocks/cover/available.js
@@ -43,7 +43,7 @@ export const getAvailableCovers = () => {
       reportingPeriod: 7 * DAYS,
       resolutionSources: [
         "https://twitter.com/ClearpoolFin",
-        "https://medium.com/compound-finance",
+        "https://clearpool.medium.com/",
         "https://twitter.com/neptunemutual",
       ],
       reassuranceToken: {
@@ -251,8 +251,7 @@ export const getAvailableCovers = () => {
       stakeWithFees: convertToUnits(50_000).toString(),
       initialLiquidity: convertToUnits(50_000).toString(),
       minReportingStake: convertToUnits(500).toString(),
-      about:
-        "Huobi is a Seychelles-based cryptocurrency exchange.",
+      about: "Huobi is a Seychelles-based cryptocurrency exchange.",
       tags: ["Exchange", "DeFi", "Lending"],
 
       rules: `1. You must have maintained at least 1 NPM tokens in your wallet during your coverage period.
@@ -261,7 +260,8 @@ export const getAvailableCovers = () => {
       4. The protocol promised but later were unable to cover, write off, or bear at least 75% of the sufferred loss on behalf of their users within 30 days of the incident`,
       links: {
         website: "https://www.huobi.com/en-us/",
-        documentation: "https://docs.huobigroup.com/docs/option/v1/en/#introduction",
+        documentation:
+          "https://docs.huobigroup.com/docs/option/v1/en/#introduction",
         telegram: "https://t.me/huobiglobalofficial",
         twitter: "https://twitter.com/HuobiGlobal",
         github: "https://github.com/huobiapi",

--- a/src/components/UI/organisms/cover/add-liquidity/details.jsx
+++ b/src/components/UI/organisms/cover/add-liquidity/details.jsx
@@ -44,7 +44,11 @@ export const CoverAddLiquidityDetailsPage = ({ children }) => {
               {children}
             </div>
 
-            <CoverPurchaseResolutionSources>
+            <CoverPurchaseResolutionSources
+              covername={title}
+              knowledgebase={coverInfo?.resolutionSources[1]}
+              twitter={coverInfo?.resolutionSources[0]}
+            >
               <hr className="mt-4 mb-6 border-t border-B0C4DB/60" />
               <div className="flex justify-between pb-2">
                 <span className="">Total Liquidity::</span>

--- a/src/components/UI/organisms/cover/my-liquidity/details.jsx
+++ b/src/components/UI/organisms/cover/my-liquidity/details.jsx
@@ -53,7 +53,11 @@ export const MyLiquidityDetailsPage = ({ children }) => {
               {children}
             </div>
 
-            <CoverPurchaseResolutionSources>
+            <CoverPurchaseResolutionSources
+              covername={title}
+              knowledgebase={coverInfo?.resolutionSources[1]}
+              twitter={coverInfo?.resolutionSources[0]}
+            >
               <div className="flex justify-between pt-4 pb-2">
                 <span className="">Total Liquidity:</span>
                 <strong className="text-right font-bold">$ 2.5M</strong>

--- a/src/components/UI/organisms/cover/purchase/resolution-sources.jsx
+++ b/src/components/UI/organisms/cover/purchase/resolution-sources.jsx
@@ -1,22 +1,33 @@
 import { OutlinedCard } from "@/components/UI/molecules/outlined-card";
 import Link from "next/link";
 
-export const CoverPurchaseResolutionSources = ({ children = null }) => {
+export const CoverPurchaseResolutionSources = ({
+  children = null,
+  knowledgebase,
+  twitter,
+  covername,
+}) => {
   return (
     <div>
       <OutlinedCard className="bg-DEEAF6 p-10">
         <h3 className="text-h4 font-sora font-semibold">Resolution Sources</h3>
         <p className="text-sm mt-1 mb-6 opacity-50">7 days reporting period</p>
 
-        <Link href="https://uniswap.org/developers">
-          <a className="block text-4e7dd9 hover:underline mt-3">
-            Uniswap Knowledgebase
+        <Link href={knowledgebase}>
+          <a
+            target="_blank"
+            className="block text-4e7dd9 hover:underline mt-3 capitalize"
+          >
+            {covername} Knowledgebase
           </a>
         </Link>
 
-        <Link href="https://twitter.com/UniSwap">
-          <a className="block text-4e7dd9 hover:underline mt-3">
-            Uniswap Twitter
+        <Link href={twitter}>
+          <a
+            target="_blank"
+            className="block text-4e7dd9 hover:underline mt-3 capitalize"
+          >
+            {covername} Twitter
           </a>
         </Link>
 

--- a/src/components/UI/organisms/reporting/new/ReportingHero.jsx
+++ b/src/components/UI/organisms/reporting/new/ReportingHero.jsx
@@ -11,7 +11,7 @@ export const ReportingHero = ({ coverInfo, imgSrc, title }) => {
       <Container className="px-2 py-20">
         <BreadCrumbs
           pages={[
-            { name: "Reporting", href: "/reporting", current: false },
+            { name: "Home", href: "/", current: false },
             { name: title, current: false },
             { name: "Report", href: "#", current: true },
           ]}

--- a/src/components/pages/cover/purchase/checkout.jsx
+++ b/src/components/pages/cover/purchase/checkout.jsx
@@ -52,7 +52,11 @@ export const CoverPurchaseCheckoutPage = () => {
             </div>
           </div>
 
-          <CoverPurchaseResolutionSources />
+          <CoverPurchaseResolutionSources
+            covername={title}
+            knowledgebase={coverInfo?.resolutionSources[1]}
+            twitter={coverInfo?.resolutionSources[0]}
+          />
         </Container>
       </div>
 

--- a/src/components/pages/cover/purchase/details.jsx
+++ b/src/components/pages/cover/purchase/details.jsx
@@ -74,7 +74,11 @@ export const CoverPurchaseDetailsPage = () => {
             </AcceptRulesForm>
           </div>
 
-          <CoverPurchaseResolutionSources />
+          <CoverPurchaseResolutionSources
+            covername={title}
+            knowledgebase={coverInfo?.resolutionSources[1]}
+            twitter={coverInfo?.resolutionSources[0]}
+          />
         </Container>
       </div>
 

--- a/src/components/pages/reporting/details/CoverReportingDetailsPage.jsx
+++ b/src/components/pages/reporting/details/CoverReportingDetailsPage.jsx
@@ -78,7 +78,11 @@ export const CoverReportingDetailsPage = () => {
               </AcceptReportRulesForm>
             </div>
           </div>
-          <CoverPurchaseResolutionSources>
+          <CoverPurchaseResolutionSources
+            covername={title}
+            knowledgebase={coverInfo?.resolutionSources[1]}
+            twitter={coverInfo?.resolutionSources[0]}
+          >
             <Link href="#">
               <a className="block text-4e7dd9 hover:underline mt-3">
                 Neptune Mutual Reporters


### PR DESCRIPTION
Updated `<CoverPurchaseResolutionSources />` to have corresponding links to their knowledgebase (blog for now) and twitter links.